### PR TITLE
Add ErrWalletInvalidAccount

### DIFF
--- a/jsonerr.go
+++ b/jsonerr.go
@@ -114,6 +114,10 @@ var (
 		Code:    -17,
 		Message: "Wallet is already unlocked",
 	}
+	ErrWalletInvalidAccount = Error{
+		Code:    -18,
+		Message: "Invalid account",
+	}
 )
 
 // Specific Errors related to commands.  These are the ones a user of the rpc


### PR DESCRIPTION
As mentioned in review at https://github.com/conformal/btcwallet/pull/155 we need a `btcjson` error type to indicate error dude to invalid account. To support this, I've added a new err `ErrWalletInvalidAccount`