### PR TITLE
Remove `omitempty` fromTxRawResult confirmations

### DIFF
--- a/jsonresults.go
+++ b/jsonresults.go
@@ -410,7 +410,7 @@ type TxRawResult struct {
 	Vin           []Vin  `json:"vin"`
 	Vout          []Vout `json:"vout"`
 	BlockHash     string `json:"blockhash,omitempty"`
-	Confirmations uint64 `json:"confirmations,omitempty"`
+	Confirmations uint64 `json:"confirmations"`
 	Time          int64  `json:"time,omitempty"`
 	Blocktime     int64  `json:"blocktime,omitempty"`
 }


### PR DESCRIPTION
* Previously both `searchrawtransaction` and `getrawtransaction` would omit
the `Confirmations` field by default if the transaction was found in
the mempool.
* By removing `omitempty`, a mempool transaction will now have
`"Confirmations:0"`, instead of omitting the field altogether. 
*  This PR is related to conformal/btcd#205